### PR TITLE
Update to support new versions of Mockito

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,13 +43,13 @@
     </scm>
     <properties>
         <!-- Dependencies version -->
-        <mockito.version>1.9.5</mockito.version>
+        <mockito.version>2.10.0</mockito.version>
         <testng.version>6.8</testng.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
         </dependency>
         <dependency>
@@ -59,4 +59,28 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <id>codenvy-public-repo</id>
+            <name>codenvy public</name>
+            <url>https://maven.codenvycorp.com/content/groups/public/</url>
+        </repository>
+        <repository>
+            <id>codenvy-public-snapshots-repo</id>
+            <name>codenvy public snapshots</name>
+            <url>https://maven.codenvycorp.com/content/repositories/codenvy-public-snapshots/</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>codenvy-public-repo</id>
+            <name>codenvy public</name>
+            <url>https://maven.codenvycorp.com/content/groups/public/</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>codenvy-public-snapshots-repo</id>
+            <name>codenvy public snapshots</name>
+            <url>https://maven.codenvycorp.com/content/repositories/codenvy-public-snapshots/</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/src/main/java/org/mockito/testng/MockitoAfterTestNGMethod.java
+++ b/src/main/java/org/mockito/testng/MockitoAfterTestNGMethod.java
@@ -12,19 +12,17 @@ package org.mockito.testng;
 
 import static org.mockito.internal.util.reflection.Fields.annotatedBy;
 
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.util.reflection.Fields;
 import org.testng.IInvokedMethod;
 import org.testng.ITestResult;
-
-import java.lang.reflect.Field;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 public class MockitoAfterTestNGMethod {
 
@@ -45,8 +43,7 @@ public class MockitoAfterTestNGMethod {
     private Collection<Object> instanceMocksOf(Object instance) {
         return Fields.allDeclaredFieldsOf(instance)
                                             .filter(annotatedBy(Mock.class,
-                                                                Spy.class,
-                                                                MockitoAnnotations.Mock.class))
+                                                                Spy.class))
                                             .notNull()
                                             .assignedValues();
     }


### PR DESCRIPTION
 - mockito-all is no longer existing (switch to mockito-core)
 - remove import of annotation MockitoAnnotations.Mock.class (which no longer exists)

Add maven repositories so 'mvn clean install' is working.